### PR TITLE
Due to target API 16 we need to set hash-style=both, otherwise we get…

### DIFF
--- a/jni/Android.mk
+++ b/jni/Android.mk
@@ -19,5 +19,5 @@ LOCAL_SRC_FILES         := ../build/shell.c ../build/sqlite3.c
 LOCAL_C_INCLUDES        := ../build
 LOCAL_EXPORT_C_INCLUDES := ../build
 LOCAL_CFLAGS            := -Oz -fPIE -fstack-protector-strong -fno-rtti -fno-unroll-loops -fmerge-all-constants -fno-ident -D_FILE_OFFSET_BITS=64 -DSQLITE_THREADSAFE=1
-LOCAL_LDFLAGS           := -fstack-protector-strong -fPIE -pie -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,-z,norelro -Wl,--hash-style=gnu -Wl,--build-id=none
+LOCAL_LDFLAGS           := -fstack-protector-strong -fPIE -pie -ffunction-sections -fdata-sections -Wl,--gc-sections -Wl,-z,norelro -Wl,--hash-style=both -Wl,--build-id=none
 include $(BUILD_EXECUTABLE)


### PR DESCRIPTION
… linker errors on <= Android 5.1